### PR TITLE
chore: Add analyzer languages.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,12 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`
@@ -24,6 +30,5 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options


### PR DESCRIPTION
`$ flutter create` → Generate `analysis_options.yaml` automatically.

Set the `analyzer language` rules.
- https://github.com/dart-lang/language/blob/main/resources/type-system/strict-casts.md
- https://github.com/dart-lang/language/blob/main/resources/type-system/strict-inference.md
- https://github.com/dart-lang/language/blob/main/resources/type-system/strict-raw-types.md